### PR TITLE
Fix ARM64 support for old terraform versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.2.3 (Feb 9, 2022)
+
+ * Fix: mktemp not working correctly on Alpine Linux (#285)
+ * Add support of ARM64 (#280)
+ * Add support for tf.json files on min-required (#277)
+ * Fix issue #210 - allow non-numeric values for DEBUG (#274)
+ * Download latest version if user uses regex and TFENV_AUTO_INSTALL is true (#272)
+ * Add tfenv pin command (#270)
+
 ## 2.2.2 (May 6, 2021)
 
  * remove trust from revoked signing key as of hcsec-2021-12

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -88,7 +88,12 @@ case "$(uname -m)" in
     # There is no arm64 support for versions:
     # < 0.11.15
     # >= 0.12.0, < 0.12.30
-    if [[ "${version}" =~ 0\.(([0-9]|1[0-1])).[0-1][0-4]?$ || "${version}" =~ 0\.12\.[0-2][0-9]?$ ]]; then
+    # >= 0.13.0, < 0.13.5
+    if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
+          "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
+          "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
+          "${version}" =~ 0\.13\.[0-4]$
+    ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
     else
       TFENV_ARCH="${TFENV_ARCH:-arm64}";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -88,12 +88,10 @@ case "$(uname -m)" in
     # There is no arm64 support for versions:
     # < 0.11.15
     # >= 0.12.0, < 0.12.30
-    if [[ "${version}" =~ (0\.(([0-9]|1[0-1])).[0-1][0-4]?$) ]] || [[ "${version}" =~ 0\.12\.[0-2][0-9]?$ ]] ; then
+    if [[ "${version}" =~ 0\.(([0-9]|1[0-1])).[0-1][0-4]?$ || "${version}" =~ 0\.12\.[0-2][0-9]?$ ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
-      echo "1"
     else
       TFENV_ARCH="${TFENV_ARCH:-arm64}";
-      echo "2"
     fi;
     ;;
   *)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -85,7 +85,16 @@ fi;
 # Add support of ARM64 for Linux & Apple Silicon
 case "$(uname -m)" in
   aarch64* | arm64*)
-    TFENV_ARCH="${TFENV_ARCH:-arm64}";
+    # There is no arm64 support for versions:
+    # < 0.11.15
+    # >= 0.12.0, < 0.12.30
+    if [[ "${version}" =~ (0\.(([0-9]|1[0-1])).[0-1][0-4]?$) ]] || [[ "${version}" =~ 0\.12\.[0-2][0-9]?$ ]] ; then
+      TFENV_ARCH="${TFENV_ARCH:-amd64}";
+      echo "1"
+    else
+      TFENV_ARCH="${TFENV_ARCH:-arm64}";
+      echo "2"
+    fi;
     ;;
   *)
     TFENV_ARCH="${TFENV_ARCH:-amd64}";


### PR DESCRIPTION
There are no old Terraform **ARM64** versions in hashicorp repo

Examples:
[0.11.14](https://releases.hashicorp.com/terraform/0.11.14/)
[0.12.29](https://releases.hashicorp.com/terraform/0.12.29/)
[0.6.16](https://releases.hashicorp.com/terraform/0.6.16/)