### PR TITLE
Fix arm64 support darwin

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -107,12 +107,12 @@ esac;
 case "$(uname -s)" in
   Darwin*)
     # ARM for darwin only is available for versions >= 1.0.2
-    if [[ "${version}" =~ 1\.0\.(([2-9]|1[0-1]]))$ || 
-	  ! "${version}" =~ 0\.\d*.\d*
+    if [[ "${version}" =~ 1\.0\.[0-1]$ || 
+	  "${version}" =~ 0\.\d*.\d*
     ]]; then
-      os="darwin_${TFENV_ARCH}";
-    else
       os="darwin_amd64";
+    else
+      os="darwin_${TFENV_ARCH}";
     fi;
     ;;
   MINGW64*)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -106,7 +106,14 @@ esac;
 
 case "$(uname -s)" in
   Darwin*)
-    os="darwin_${TFENV_ARCH}";
+    # ARM for darwin only is available for versions >= 1.0.2
+    if [[ "${version}" =~ 1\.0\.(([2-9]|1[0-1]]))$ || 
+	  ! "${version}" =~ 0\.\d*.\d*
+    ]]; then
+      os="darwin_${TFENV_ARCH}";
+    else
+      os="darwin_amd64";
+    fi;
     ;;
   MINGW64*)
     os="windows_${TFENV_ARCH}";
@@ -118,7 +125,7 @@ case "$(uname -s)" in
     os="windows_${TFENV_ARCH}";
     ;;
   FreeBSD*)
-    os="freebsd_${TFENV_ARCH}"
+    os="freebsd_${TFENV_ARCH}";
     ;;
   *)
     os="linux_${TFENV_ARCH}";


### PR DESCRIPTION
Fixed support for ARM64 in Darwin (MacOS)  on versions <1.0.2 @Samusia 